### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ docker run -d -p 4444:4444 -v /dev/shm:/dev/shm -v "$WORKSPACE:$WORKSPACE" sel
 Run these commands to download data from the NYSE website and take the data's hash.
 
 ```bash
-$ cardano-entropy nyse --workspace="$WORKSPACE" --username="$USERNAME" --password="$PASSWORD" --date="$DATE"
+$ cardano-entropy nyse --workspace="$WORKSPACE" --username="$USERNAME" --password="$PASSWORD" --end-date="$DATE"
 Downloaded: /Users/jky/tmp/download-0ac80eea1ebf36da/NYSE_20210319.csv
 Hash: 42e1611e701d4b8885da5ef5cf54f2e4a56f77b675835fcae6c132aff09a0f46
 ```


### PR DESCRIPTION
Just one change, changed '--date' to '--end-date'

## Download NYSE data and take its hash

Run these commands to download data from the NYSE website and take the data's hash.

```bash
$ cardano-entropy nyse --workspace="$WORKSPACE" --username="$USERNAME" --password="$PASSWORD" --end-date="$DATE"
Downloaded: /Users/jky/tmp/download-0ac80eea1ebf36da/NYSE_20210319.csv
Hash: 42e1611e701d4b8885da5ef5cf54f2e4a56f77b675835fcae6c132aff09a0f46